### PR TITLE
fix #5 - Remove entrada duplicada do setuptools

### DIFF
--- a/1.1.3.1/versions.cfg
+++ b/1.1.3.1/versions.cfg
@@ -244,7 +244,6 @@ robotframework-ride = 1.3
 robotframework-selenium2library = 1.4.0
 robotsuite = 1.3.3
 selenium = 2.37.2
-setuptools = 0.6c11
 z3c.coverage = 1.2.0
 z3c.ptcompat = 1.0.1
 z3c.template = 1.4.1


### PR DESCRIPTION
A biblioteca setuptools aparece duas vezes no versions.cfg. Remove uma das entradas para evitar erros quando for necessário atualizá-la.