### PR TITLE
Atualiza as versões para Plone 4.3.9.

### DIFF
--- a/1.1.4-pending/versions.cfg
+++ b/1.1.4-pending/versions.cfg
@@ -1,6 +1,6 @@
 [buildout]
 find-links =
-    http://dist.plone.org/release/4.3.7
+    http://dist.plone.org/release/4.3.9
     http://dist.plone.org/thirdparty
 
 package-name = brasil.gov.portal
@@ -12,7 +12,8 @@ zcml =
 versions = versions
 
 [versions]
-## http://dist.plone.org/versions/zopetoolkit-1-0-8-zopeapp-versions.cfg
+# Downloaded from http://download.zope.org/zopetoolkit/index/1.0.8/zopeapp-versions.cfg
+# ZopeApp
 zope.app.applicationcontrol = 3.5.10
 zope.app.appsetup = 3.14.0
 zope.app.authentication = 3.8.0
@@ -40,6 +41,7 @@ zope.app.renderer = 3.5.1
 zope.app.rotterdam = 3.5.3
 zope.app.schema = 3.5.0
 zope.app.security = 3.7.5
+# zope.app.testing branch which is compatible with zope.testbrowser 3.8.
 zope.app.testing = 3.7.8
 zope.app.wsgi = 3.9.3
 zope.app.zcmlfiles = 3.7.1
@@ -47,7 +49,10 @@ zope.app.zopeappgenerations = 3.5.1
 roman = 1.4.0
 wsgi-intercept = 0.4
 zc.sourcefactory = 0.7.0
+# Next major version of zope.testbrowser fails on py24.
 zope.testbrowser = 3.8.2
+
+# Deprecating
 zodbcode = 3.4.0
 zope.app.apidoc = 3.7.5
 zope.app.cache = 3.7.0
@@ -80,7 +85,8 @@ zope.thread = 3.4
 zope.xmlpickle = 3.4.0
 zope.rdb = 3.5.0
 
-## http://dist.plone.org/versions/zopetoolkit-1-0-8-ztk-versions.cfg
+# Downloaded from http://download.zope.org/zopetoolkit/index/1.0.8/ztk-versions.cfg
+# ZTK
 zope.annotation = 3.5.0
 zope.applicationcontrol = 3.5.5
 zope.authentication = 3.7.1
@@ -146,11 +152,17 @@ zope.tales = 3.5.3
 zope.testing = 3.9.7
 zope.traversing = 3.13.2
 zope.viewlet = 3.7.2
+
+# Deprecating
 zope.documenttemplate = 3.4.3
+
+# Dependencies
+# Needed for the mechanize 0.1.x.
 ClientForm = 0.2.10
 distribute = 0.6.36
 docutils = 0.7
 Jinja2 = 2.5.5
+# Newer versions of mechanize are not fully py24 compatible.
 mechanize = 0.1.11
 Paste = 1.7.5.1
 PasteDeploy = 1.3.4
@@ -174,6 +186,8 @@ zc.resourcelibrary = 1.3.4
 zdaemon = 2.0.7
 ZODB3 = 3.9.7
 zope.mkzeoinstance = 3.9.5
+
+# toolchain
 argparse = 1.1
 coverage = 3.5.2
 lxml = 2.2.8
@@ -185,9 +199,9 @@ z3c.recipe.compattest = 0.12.2
 z3c.recipe.depgraph = 0.5
 zope.kgs = 1.2.0
 
-## http://dist.plone.org/versions/zope-2-13-23-versions.cfg
-Zope2 = 2.13.23
-AccessControl = 2.13.13
+#  Compiled from http://download.zope.org/Zope2/index/2.13.24/versions.cfg
+Zope2 = 2.13.24
+AccessControl = 2.13.14
 Acquisition = 2.13.9
 DateTime = 2.12.8
 DocumentTemplate = 2.13.2
@@ -211,40 +225,55 @@ tempstorage = 2.12.2
 zExceptions = 2.13.0
 zLOG = 2.11.2
 ZopeUndo = 2.12.0
+
+# Zope2 dependencies
 ZConfig = 2.9.3
 ZODB3 = 3.10.5
 mechanize = 0.2.5
-pytz = 2015.4
+pytz = 2015.7
 repoze.retry = 1.2
 repoze.tm2 = 1.0
 repoze.who = 2.0
 
-## http://dist.plone.org/release/4.3.7/versions.cfg
+## http://dist.plone.org/release/4.3.9/versions.cfg
+# Zope overrides
 docutils = 0.12
+# Get support for @security decorators
 AccessControl = 3.0.11
+# More memory efficient version, Trac #13101
 DateTime = 3.0.3
+# Products.BTreeFolder2 2.13.4 causes a regression
 Products.BTreeFolder2 = 2.13.3
+# Override until ztk is updated
 Sphinx = 1.1.3
+# required for recent z3c.form and chameleon
 zope.pagetemplate = 3.6.3
+# Required for IE10 fix in orderedSelectionList.pt:
 zope.formlib = 4.3.0
+# Several tests rely on an old-style pytz release:
 pytz = 2013b
+
+# Build tools
 buildout.dumppickedversions = 0.5
 collective.recipe.omelette = 0.15
 collective.recipe.template = 1.9
 collective.xmltestreport = 1.3.3
 decorator = 3.4.2
+i18ndude = 4.0.1
 distribute = 0.6.28
+setuptools = 20.1.1
 mr.developer = 1.33
 plone.recipe.alltests = 1.5
 plone.recipe.zeoserver = 1.2.8
-plone.recipe.zope2instance = 4.2.18
-setuptools = 0.6c11
+plone.recipe.zope2instance = 4.2.20
 z3c.coverage = 1.2.0
 z3c.ptcompat = 1.0.1
 z3c.template = 1.4.1
-zest.releaser = 3.43
+zest.releaser = 6.6.2
 zope.testrunner = 4.4.4
-plone.app.robotframework = 0.9.9
+
+# Robot Testing
+plone.app.robotframework = 0.9.15
 robotframework = 2.8.4
 robotframework-selenium2library = 1.5.0
 robotsuite = 1.6.0
@@ -257,214 +286,217 @@ sphinxcontrib-robotframework = 0.4.3
 robotframework-debuglibrary = 0.3
 sphinx-rtd-theme = 0.1.5
 Pygments = 2.0.2
+
+# External dependencies
 Markdown = 2.0.3
 PIL = 1.1.7
 Pillow = 2.7.0
+# Unidecode 0.04.{2-9} break tests
 Unidecode = 0.04.1
 elementtree = 1.2.7-20070827-preview
 experimental.cssselect = 0.3
 Jinja2 = 2.7.3
 feedparser = 5.0.1
+future = 0.13.1
+importlib = 1.0.3
 lxml = 2.3.6
 mailinglogger = 3.7.0
 ordereddict = 1.1
 python-dateutil = 1.5
 python-openid = 2.2.5
-repoze.xmliter = 0.5
+repoze.xmliter = 0.6
 simplejson = 2.5.2
-six = 1.8.0
-WebOb = 1.0.8
+six = 1.10.0
+WebOb = 1.4.1
+
+# Python 2.6 dependencies
 select-backport = 0.2
-Plone = 4.3.7
-Products.ATContentTypes = 2.1.16
-Products.ATReferenceBrowserWidget = 3.0
-Products.Archetypes = 1.9.10
-Products.CMFActionIcons = 2.1.3
-Products.CMFCalendar = 2.2.3
-Products.CMFCore = 2.2.9
-Products.CMFDefault = 2.2.4
-Products.CMFDiffTool = 2.1.1
-Products.CMFDynamicViewFTI = 4.1.3
-Products.CMFEditions = 2.2.16
-Products.CMFFormController = 3.0.5
-Products.CMFPlacefulWorkflow = 1.5.11
-Products.CMFPlone = 4.3.7
-Products.CMFQuickInstallerTool = 3.0.12
-Products.CMFTestCase = 0.9.12
-Products.CMFTopic = 2.2.1
-Products.CMFUid = 2.2.1
-Products.contentmigration = 2.1.11
-Products.DCWorkflow = 2.2.4
-Products.ExtendedPathIndex = 3.1
-Products.ExternalEditor = 1.1.0
-Products.GenericSetup = 1.7.7
-Products.Marshall = 2.1.4
-Products.MimetypesRegistry = 2.0.8
-Products.PasswordResetTool = 2.0.18
-Products.PlacelessTranslationService = 2.0.5
-Products.PloneLanguageTool = 3.2.7
-Products.PlonePAS = 4.1.5
-Products.PloneTestCase = 0.9.18
-Products.PluggableAuthService = 1.10.0
-Products.PluginRegistry = 1.3
-Products.PortalTransforms = 2.1.10
-Products.ResourceRegistries = 2.2.11
-Products.SecureMailHost = 1.1.2
-Products.TinyMCE = 1.3.14
-Products.ZopeVersionControl = 1.1.3
-Products.ZSQLMethods = 2.13.4
-Products.i18ntestcase = 1.3
-Products.statusmessages = 4.0
-Products.validation = 2.0.1
-archetypes.querywidget = 1.1.2
-archetypes.referencebrowserwidget = 2.5.4
-archetypes.schemaextender = 2.1.5
-borg.localrole = 3.0.2
-collective.monkeypatcher = 1.1.1
-collective.testcaselayer = 1.6.1
-collective.z3cform.datetimewidget = 1.2.7
-diazo = 1.0.6
-five.customerize = 1.1
-five.formlib = 1.0.4
-five.globalrequest = 1.0
-five.localsitemanager = 2.0.5
-plone.app.blob = 1.5.16
-plone.app.caching = 1.1.10
-plone.app.collection = 1.0.13
-plone.app.content = 2.1.5
-plone.app.contentlisting = 1.0.5
-plone.app.contentmenu = 2.0.11
-plone.app.contentrules = 3.0.8
-plone.app.controlpanel = 2.3.9
-plone.app.customerize = 1.2.3
-plone.app.dexterity = 2.0.16
-plone.app.discussion = 2.2.15
-plone.app.folder = 1.1.0
-plone.app.form = 2.2.6
-plone.app.i18n = 2.0.3
-plone.app.imaging = 1.0.11
-plone.app.iterate = 2.1.13
-plone.app.jquery = 1.7.2.1
-plone.app.jquerytools = 1.7.0
-plone.app.layout = 2.3.13
-plone.app.linkintegrity = 1.5.6
-plone.app.locales = 4.3.7
-plone.app.openid = 2.0.4
-plone.app.portlets = 2.5.4
-plone.app.querystring = 1.2.7
-plone.app.redirector = 1.2.2
-plone.app.registry = 1.2.4
-plone.app.search = 1.1.8
-plone.app.testing = 4.2.5
-plone.app.textfield = 1.2.6
-plone.app.theming = 1.1.7
-plone.app.upgrade = 1.3.18
-plone.app.users = 1.2.2
-plone.app.uuid = 1.1
-plone.app.viewletmanager = 2.0.8
-plone.app.vocabularies = 2.1.20
-plone.app.workflow = 2.1.9
-plone.app.z3cform = 0.7.7
-plone.alterego = 1.0
-plone.autoform = 1.6.1
-plone.batching = 1.0.5
-plone.behavior = 1.1
-plone.browserlayer = 2.1.5
-plone.cachepurging = 1.0.9
-plone.caching = 1.0.1
-plone.contentrules = 2.0.4
-plone.dexterity = 2.2.4
-plone.fieldsets = 2.0.3
-plone.folder = 1.0.7
-plone.formwidget.namedfile = 1.0.13
-plone.i18n = 2.0.10
-plone.indexer = 1.0.3
-plone.intelligenttext = 2.0.3
-plone.keyring = 3.0.1
-plone.locking = 2.0.8
-plone.memoize = 1.1.1
-plone.namedfile = 2.0.9
-plone.openid = 2.0.4
-plone.outputfilters = 1.15
-plone.portlet.collection = 2.1.8
-plone.portlet.static = 2.0.4
-plone.portlets = 2.2
-plone.protect = 2.0.2
-plone.registry = 1.0.2
-plone.reload = 2.0
-plone.resource = 1.0.4
-plone.resourceeditor = 1.0
-plone.rfc822 = 1.1.1
-plone.scale = 1.3.5
-plone.schemaeditor = 1.3.11
-plone.session = 3.5.6
-plone.stringinterp = 1.0.13
-plone.subrequest = 1.6.9
-plone.supermodel = 1.2.6
-plone.synchronize = 1.0.1
-plone.testing = 4.0.15
-plone.theme = 2.1.5
-plone.transformchain = 1.0.4
-plone.uuid = 1.0.3
-plone.z3cform = 0.8.1
-plonetheme.classic = 1.3.3
-plonetheme.sunburst = 1.4.7
-rwproperty = 1.0
-wicked = 1.1.12
-z3c.autoinclude = 0.3.5
-z3c.batching = 1.1.0
-z3c.blobfile = 0.1.5
-z3c.caching = 2.0a1
-z3c.form = 3.2.4
-z3c.formwidget.query = 0.11
-z3c.zcmlhook = 1.0b1
-zope.globalrequest = 1.1
-zope.schema = 4.2.2
-exifread = 2.1.2
-collective.js.jqueryui = 1.10.3
-five.grok = 1.3.2
-five.intid = 1.0.3
-grokcore.annotation = 1.3
-grokcore.component = 2.5
-grokcore.formlib = 1.9
-grokcore.security = 1.6.2
-grokcore.site = 1.6.1
-grokcore.view = 2.8
-grokcore.viewlet = 1.11
-manuel = 1.8.0
-martian = 0.14
-mocker = 1.1.1
-plone.app.contenttypes = 1.1b5
-plone.app.event = 1.1.5
-plone.app.intid = 1.0.5
-plone.app.lockingbehavior = 1.0.1
-plone.app.referenceablebehavior = 0.7.0
-plone.app.relationfield = 1.2.1
-plone.app.stagingbehavior = 0.1
-plone.app.versioningbehavior = 1.2.0
-plone.app.widgets = 1.8.0
-plone.directives.dexterity = 1.0.2
-plone.directives.form = 2.0.1
-plone.formwidget.autocomplete = 1.2.8
-plone.formwidget.contenttree = 1.0.9
-plone.formwidget.recurrence = 1.2.6
-plone.mocktestcase = 1.0b3
-z3c.objpath = 1.1
-z3c.relationfield = 0.6.3
-zc.relation = 1.0
-zope.testbrowser = 3.11.1
 
-## Good known versions for plone.app.robotframework and friends
-Pygments = 2.0.2
-plone.app.robotframework = 0.9.14
-robotframework = 2.9.2
-robotframework-selenium2library = 1.7.4
-robotframework-selenium2screenshots = 0.6.0
-robotsuite = 1.7.0
-selenium = 2.48.0
-sphinxcontrib-robotframework = 0.5.1
+# Plone release
+Plone                                 = 4.3.9
+Products.ATContentTypes               = 2.1.18
+Products.ATReferenceBrowserWidget     = 3.0
+Products.Archetypes                   = 1.9.10
+Products.CMFActionIcons               = 2.1.3
+Products.CMFCalendar                  = 2.2.3
+Products.CMFCore                      = 2.2.9
+Products.CMFDefault                   = 2.2.4
+Products.CMFDiffTool                  = 2.1.2
+Products.CMFDynamicViewFTI            = 4.1.3
+Products.CMFEditions                  = 2.2.19
+Products.CMFFormController            = 3.0.5
+Products.CMFPlacefulWorkflow          = 1.5.13
+Products.CMFPlone                     = 4.3.9
+Products.CMFQuickInstallerTool        = 3.0.13
+Products.CMFTestCase                  = 0.9.12
+Products.CMFTopic                     = 2.2.1
+Products.CMFUid                       = 2.2.1
+Products.contentmigration             = 2.1.11
+Products.DCWorkflow                   = 2.2.4
+Products.ExtendedPathIndex            = 3.1
+Products.ExternalEditor               = 1.1.0
+Products.GenericSetup                 = 1.8.2
+Products.Marshall                     = 2.1.4
+Products.MimetypesRegistry            = 2.0.8
+Products.PasswordResetTool            = 2.0.18
+Products.PlacelessTranslationService  = 2.0.5
+Products.PloneLanguageTool            = 3.2.7
+Products.PlonePAS                     = 5.0.9
+Products.PloneTestCase                = 0.9.18
+Products.PluggableAuthService         = 1.11.0
+Products.PluginRegistry               = 1.4
+Products.PortalTransforms             = 2.1.11
+Products.ResourceRegistries           = 2.2.11
+Products.SecureMailHost               = 1.1.2
+Products.TinyMCE                      = 1.3.18
+Products.ZopeVersionControl           = 1.1.3
+Products.ZSQLMethods                  = 2.13.4
+Products.i18ntestcase                 = 1.3
+Products.statusmessages               = 4.0
+Products.validation                   = 2.0.1
+archetypes.querywidget                = 1.1.2
+archetypes.referencebrowserwidget     = 2.5.7
+archetypes.schemaextender             = 2.1.5
+borg.localrole                        = 3.0.2
+collective.monkeypatcher              = 1.1.1
+collective.testcaselayer              = 1.6.1
+collective.z3cform.datetimewidget     = 1.2.7
+diazo                                 = 1.1.3
+five.customerize                      = 1.1
+five.formlib                          = 1.0.4
+five.globalrequest                    = 1.0
+five.localsitemanager                 = 2.0.5
+plone.app.blob                        = 1.5.17
+plone.app.caching                     = 1.1.11
+plone.app.collection                  = 1.0.13
+plone.app.content                     = 2.1.5
+plone.app.contentlisting              = 1.0.5
+plone.app.contentmenu                 = 2.0.11
+plone.app.contentrules                = 3.0.9
+plone.app.controlpanel                = 2.3.9
+plone.app.customerize                 = 1.2.3
+plone.app.dexterity                   = 2.0.17
+plone.app.discussion                  = 2.2.16
+plone.app.folder                      = 1.1.2
+plone.app.form                        = 2.2.7
+plone.app.i18n                        = 2.0.3
+plone.app.imaging                     = 1.0.13
+plone.app.iterate                     = 2.1.15
+plone.app.jquery                      = 1.7.2.1
+plone.app.jquerytools                 = 1.7.0
+plone.app.layout                      = 2.3.14
+plone.app.linkintegrity               = 1.5.8
+plone.app.locales                     = 4.3.10
+plone.app.openid                      = 2.0.4
+plone.app.portlets                    = 2.5.4
+plone.app.querystring                 = 1.2.9
+plone.app.redirector                  = 1.2.2
+plone.app.registry                    = 1.2.4
+plone.app.search                      = 1.1.8
+plone.app.testing                     = 4.2.5
+plone.app.textfield                   = 1.2.6
+plone.app.theming                     = 1.1.7
+plone.app.upgrade                     = 1.3.22
+plone.app.users                       = 1.2.4
+plone.app.uuid                        = 1.1
+plone.app.viewletmanager              = 2.0.9
+plone.app.vocabularies                = 2.1.23
+plone.app.workflow                    = 2.1.9
+plone.app.z3cform                     = 0.7.7
+plone.alterego                        = 1.0
+plone.autoform                        = 1.6.2
+plone.batching                        = 1.0.8
+plone.behavior                        = 1.1.1
+plone.browserlayer                    = 2.1.6
+plone.cachepurging                    = 1.0.11
+plone.caching                         = 1.0.1
+plone.contentrules                    = 2.0.5
+plone.dexterity                       = 2.2.6
+plone.fieldsets                       = 2.0.3
+plone.folder                          = 1.0.7
+plone.formwidget.namedfile            = 1.0.15
+plone.i18n                            = 2.0.10
+plone.indexer                         = 1.0.4
+plone.intelligenttext                 = 2.1.0
+plone.keyring                         = 3.0.1
+plone.locking                         = 2.0.9
+plone.memoize                         = 1.1.2
+plone.namedfile                       = 3.0.7
+plone.openid                          = 2.0.4
+plone.outputfilters                   = 1.15.1
+plone.portlet.collection              = 2.1.10
+plone.portlet.static                  = 2.0.4
+plone.portlets                        = 2.2.2
+plone.protect                         = 2.0.3
+plone.registry                        = 1.0.3
+plone.reload                          = 2.0.1
+plone.resource                        = 1.0.5
+plone.resourceeditor                  = 1.0
+plone.rfc822                          = 1.1.2
+plone.scale                           = 1.4.1
+plone.schemaeditor                    = 1.3.11
+plone.session                         = 3.5.6
+plone.stringinterp                    = 1.0.13
+plone.subrequest                      = 1.6.11
+plone.supermodel                      = 1.2.7
+plone.synchronize                     = 1.0.1
+plone.testing                         = 4.1.1
+plone.theme                           = 2.1.5
+plone.transformchain                  = 1.1.0
+plone.uuid                            = 1.0.3
+plone.z3cform                         = 0.8.1
+plone4.csrffixes                      = 1.0.9
+plonetheme.classic                    = 1.3.3
+plonetheme.sunburst                   = 1.4.7
+rwproperty                            = 1.0
+wicked                                = 1.1.12
+z3c.autoinclude                       = 0.3.5
+z3c.batching                          = 1.1.0
+z3c.blobfile                          = 0.1.5
+z3c.caching                           = 2.0a1
+z3c.form                              = 3.2.9
+z3c.formwidget.query                  = 0.12
+z3c.zcmlhook                          = 1.0b1
+zope.globalrequest                    = 1.1
+zope.schema                           = 4.2.2
 
-## Portal Padrao 1.1
+# Ecosystem (not officially part of core)
+exifread                              = 2.1.2
+collective.js.jqueryui                = 1.10.4
+five.grok                             = 1.3.2
+five.intid                            = 1.0.3
+grokcore.annotation                   = 1.3
+grokcore.component                    = 2.5
+grokcore.formlib                      = 1.9
+grokcore.security                     = 1.6.2
+grokcore.site                         = 1.6.1
+grokcore.view                         = 2.8
+grokcore.viewlet                      = 1.11
+manuel                                = 1.8.0
+martian                               = 0.14
+mocker                                = 1.1.1
+plone.app.contenttypes                = 1.1
+plone.app.event                       = 1.1.5
+plone.app.intid                       = 1.0.5
+plone.app.lockingbehavior             = 1.0.3
+plone.app.referenceablebehavior       = 0.7.4
+plone.app.relationfield               = 1.2.3
+plone.app.stagingbehavior             = 0.1
+plone.app.versioningbehavior          = 1.2.0
+plone.app.widgets                     = 1.8.0
+plone.directives.dexterity            = 1.0.2
+plone.directives.form                 = 2.0.2
+plone.formwidget.autocomplete         = 1.2.9
+plone.formwidget.contenttree          = 1.0.13
+plone.formwidget.datetime             = 1.3
+plone.formwidget.recurrence           = 1.2.6
+plone.mocktestcase                    = 1.0b3
+z3c.objpath                           = 1.1
+z3c.relationfield                     = 0.6.3
+zc.relation                           = 1.0
+zope.testbrowser                      = 3.11.1
+
+## Portal Padrao 1.1.4
 argh = 0.23.3
 brasil.gov.agenda = 1.0.1
 brasil.gov.barra = 1.1
@@ -478,7 +510,7 @@ buildout-versions = 1.7
 Chameleon = 2.22
 collective.behavior.localdiazo = 1.0b3
 collective.behavior.localregistry = 1.0b2
-collective.cover = 1.0a12
+collective.cover = 1.1b1
 collective.dexteritytextindexer = 2.0.1
 collective.googleanalytics = 1.4.4
 collective.js.bootstrap = 2.3.1.1
@@ -502,7 +534,6 @@ flake8 = 2.4.1
 gdata = 2.0.18
 grokcore.view = 2.9
 html5lib = 1.0b3
-i18ndude = 3.3.5
 interlude = 1.1.1
 isodate = 0.5.1
 MarkupSafe = 0.18
@@ -510,12 +541,12 @@ mccabe = 0.3.1
 meld3 = 0.6.10
 pathtools = 0.1.2
 plone.api = 1.4.6
+# collective.cover, veja no setup.py dele.
 plone.app.blocks = 2.2.1
 plone.app.collection = 2.0b5
+# BBB: https://github.com/plonegovbr/brasil.gov.portal/issues/240
 plone.app.contenttypes = 1.0
 plone.app.imagetile = 1.0
-plone.app.iterate = 2.1.15
-plone.app.querystring = 1.2.9
 plone.app.texttile = 1.0
 plone.app.themingplugins = 1.0b1
 plone.app.tiles = 1.0.2
@@ -531,7 +562,6 @@ Products.PrintingMailHost = 0.7
 Products.PythonField = 1.1.3
 Products.TALESField = 1.1.3
 Products.TemplateFields = 1.2.5
-Products.TinyMCE = 1.3.18
 pyflakes = 0.8.1
 pyparsing = 1.5.7
 python-oembed = 0.2.2
@@ -559,8 +589,15 @@ z3c.unconfigure = 1.1
 zope.app.locales = 3.7.4
 zope.configuration = 3.8.1
 
+# Customizações na parte de testes do IDG
+robotframework = 2.9.2
+robotframework-selenium2library = 1.7.4
+robotframework-selenium2screenshots = 0.6.0
+robotsuite = 1.7.0
+selenium = 2.48.0
+sphinxcontrib-robotframework = 0.5.1
+
 # Plone Hotfix 20151006
 plone.keyring = 3.0.1
 plone.locking = 2.0.9
 plone.protect = 3.0.16
-plone4.csrffixes = 1.0.9


### PR DESCRIPTION
A estrutura foi um pouco modificada, de forma a ficar o mais próximo
possível dos arquivos originais onde as versões foram copiadas para
poder facilitar o diff em atualizações futuras.

Pacotes que eram pinados por esse pacote foram removidos quando o Plone
passou a piná-las automaticamente quando tinham a mesma versão.

Se algum pacote (como o i18ndude) era pinado aqui sem uma justificativa
ou documentação, e passou a ser pinado para uma versão mais nova nos
cfgs oficias do Plone e do Zope, a pinagem por parte do IDG também foi
removida.