### PR TITLE
Script versions-sem-extends.sh adicionado.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,15 @@ portalpadrao.release
 
 Esse repositório contém os arquivos com as versões utilizadas em cada release do Portal Padrão e uma explicação técnica do funcionamento do lançamento de um novo release.
 
+Por que versions.cfg e versions-sem-extends.cfg? Qual devo usar?
+-------------------------------------------------------------
+
+Até o release 1.1.4, o arquivo versions.cfg era um arquivo compilado *manualmente* não contendo nenhuma url a mais no extends.
+
+A partir do release 1.1.5, passamos a usar como referência no extends o versions do Plone para a última versão do Plone homologada pelo IDG, de forma a diminuir o retrabalho na criação desse arquivo de versões. Isso significa que o seu servidor precisará ter acesso externo à essas urls do extends para funcionar corretamente.
+
+Para situações em que você não pode usar o extends de uma url externa (ambientes sem acesso externo), baixe o versions-sem-extends.cfg para a sua instância e renomeie para versions.cfg.
+
 Passos para criação de um novo release
 ======================================
 
@@ -18,7 +27,7 @@ Ações para um novo release
 - É feita uma revisão em todas as pinagens de https://github.com/plonegovbr/portal.buildout/blob/master/buildout.d/versions.cfg (procure por FIXME, HACK, BBB) para ver se poderá ser feita alguma modificação para aquele release em específico;
 - Restartar as builds do master das dependências plonegovbr no travis;
 - Criar uma instância da última versão de brasil.gov.portal e efetuar um teste exploratório mínimo;
-- Quando todas as revisões tiverem sido feitas e estiver para lançar um release, o https://github.com/plonegovbr/portal.buildout/blob/master/buildout.d/versions.cfg será copiado para https://github.com/plonegovbr/portalpadrao.release, criando um novo diretório para aquele release;
+- Quando todas as revisões tiverem sido feitas e estiver para lançar um release, o https://github.com/plonegovbr/portal.buildout/blob/master/buildout.d/versions.cfg será copiado para https://github.com/plonegovbr/portalpadrao.release, criando um novo diretório para aquele release, e o versions-sem-extends.cfg gerado usando o script em https://github.com/plonegovbr/portalpadrao.release/blob/master/versions-sem-extends.sh
 - É feita uma alteração no `extends` de https://github.com/plonegovbr/portal.buildout/blob/master/buildout.d/base.cfg informando esse novo release criado (pode ser necessário esperar alguns minutos, pois a url http://downloads.plone.org.br/release/x.x.x/versions.cfg demora um tempo para sincronizar no github);
 - Verificar se a build do master de portal.buildout no travis está ok;
 - Criação das tags do release (esse é o **último** passo, é nessa ordem caso, durante os passos anteriores, seja necessária alguma alteração pontual):

--- a/versions-sem-extends.sh
+++ b/versions-sem-extends.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+if [ $# -eq 0 ]; then
+    echo "Preciso de um release como parâmetro. Ex: 1.1.5"
+    echo "Esse script só foi testado para versões >= 1.1.5."
+else
+    portal_padrao_idg_release="$1"
+    if git clone https://github.com/plonegovbr/portal.buildout.git /tmp/portal.buildout; then
+        cd /tmp/portal.buildout
+        if git checkout "$portal_padrao_idg_release"; then
+            python bootstrap.py -c production.cfg
+
+            # Explicando o sed:
+            # Removo a partir do '[versions]' até o início do arquivo, sendo a
+            # string '[versions]' também removida;
+            # Removo da primeira linha vazia até o fim do arquivo. É essa linha
+            # vazia que indica que a parte '[versions]' terminou;
+            # Remove todas as linhas que começam com 4 espaços, geralmente são
+            # linhas que contém as urls http;
+            # Troco todas as strings '= ' para ' = ' para melhor visibilidade,
+            # já que todos os pacotes vem como 'my.package= x.x.'
+            # Garantir que tenho valores únicos e em ordem alfabética
+            bin/buildout -c production.cfg annotate | sed '1,/\[versions\]/d' | sed '/^$/,$ d' | sed '/    /d' | sed 's/= / = /' | uniq | sort > versions-sem-extends.cfg
+
+            # Aqui, readiciono o '[versions]' removido acima e uma mensagem
+            # indicando que esse arquivo é gerado automaticamente.
+            sed -i '1s/^/\[versions\]\n# NÃO EDITE ESSE ARQUIVO, ele foi gerado dinamicamente pelo script https:\/\/raw.githubusercontent.com\/plonegovbr\/portalpadrao.release\/master\/versions-sem-extends.cfg\n# Utilize esse arquivo caso o seu servidor não possua acesso à internet, uma vez que o versions.cfg tenta acessar vários cfgs externos no extends.\n# Para maiores informações, acesse a seção "Por que versions.cfg e versions-sem-extends.cfg? Qual devo usar?" no README.md em https:\/\/github.com\/plonegovbr\/portalpadrao.release\/blob\/master\/README.md\n/' versions-sem-extends.cfg
+
+            echo "Arquivo versions-sem-extends compilado presente em $PWD/versions-sem-extends.cfg."
+        fi
+    fi
+fi


### PR DESCRIPTION
Como o nome diz, esse script gera um versions-sem-extends.sh, ou seja,
totalmente local. Isso é útil para ambientes que não possuem acesso
externo às urls do Plone.